### PR TITLE
Don't include hashtag in altnames

### DIFF
--- a/http-pub/js/app.js
+++ b/http-pub/js/app.js
@@ -99,7 +99,7 @@ require(['search'], function (Search) {
 
                         // Set HTML names
                         if (info.altnames && info.altnames.html) {
-                            htmlCodes.push('&amp;#' + info.altnames.html + ';');
+                            htmlCodes.push('&amp;' + info.altnames.html + ';');
                         }
                         tpl.find('.char-html').html(htmlCodes.join("<br>"));
 


### PR DESCRIPTION
To my knowledge, the hashtag should only be included when the character is referred to by it's number.
